### PR TITLE
Add CI Pipeline with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: golang:1.13
+    working_directory: /go/src/github.com/agonzalezro/botella
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install Docker client
+          command: |
+            set -x
+            VER="17.03.0-ce"
+            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+            mv /tmp/docker/* /usr/bin
+      - run:
+          name: Install glide and install dependencies
+          command: | 
+            curl https://glide.sh/get | sh
+            glide install
+      - run:
+          name: Run tests
+          command: go test $(glide novendor)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Botella
 =======
 
+![CircleCI](https://img.shields.io/circleci/build/github/agonzalezro/botella?style=flat-square)
+
 Bot (for Slack et al) with plugins. What's the selling point then? The plugins are Docker containers and the bot interacts with them via stdin/stdout. In plain English that means that you can develop your plugins in whatever language you want and you will just need to pack them as a Docker container to be able to use them with Botella.
 
 Install


### PR DESCRIPTION
As discussed in #1 this adds a pipeline that runs the tests on CircleCI with a remote docker env. And adds a badge to the README.